### PR TITLE
Fixed shuttle container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,29 @@
+FROM alpine:3.14
+
+ENV USER=docker
+ENV GROUP=docker
+ENV UID=1000
+
+RUN addgroup -g "$UID" "$GROUP"
+
+RUN adduser \
+    --disabled-password \
+    --gecos "" \
+    --home "/tmp/shuttle/" \
+    --ingroup "$GROUP" \
+    --no-create-home \
+    --uid "$UID" \
+    "$USER"
+
+RUN apk add --update curl git bash && \
+    rm -rf /var/cache/apk/*
+
+RUN curl -LO https://github.com/lunarway/shuttle/releases/download/$(curl -Lso /dev/null -w %{url_effective} https://github.com/lunarway/shuttle/releases/latest | grep -o '[^/]*$')/shuttle-linux-amd64
+RUN chmod +x shuttle-linux-amd64
+RUN mv shuttle-linux-amd64 /usr/local/bin/shuttle
+
+WORKDIR /tmp/shuttle/
+
+USER docker
+
+CMD ["shuttle"]

--- a/README.md
+++ b/README.md
@@ -6,38 +6,7 @@ You need [Shuttle](https://github.com/lunarway/shuttle) cli to use this repo.
 
 The desired state is defined in `shuttle.yaml` and the plan in `plan.yaml`. 
 
-Shuttle can be put in a container by
-```
-FROM alpine:3.14
-
-ENV USER=docker
-ENV GROUP=docker
-ENV UID=1000
-
-RUN addgroup -g "$UID" "$GROUP"
-
-RUN adduser \
-    --disabled-password \
-    --gecos "" \
-    --home "/tmp/shuttle/" \
-    --ingroup "$GROUP" \
-    --no-create-home \
-    --uid "$UID" \
-    "$USER"
-
-RUN apk add --update curl git && \
-    rm -rf /var/cache/apk/*
-
-RUN curl -LO https://github.com/lunarway/shuttle/releases/download/$(curl -Lso /dev/null -w %{url_effective} https://github.com/lunarway/shuttle/releases/latest | grep -o '[^/]*$')/shuttle-linux-amd64
-RUN chmod +x shuttle-linux-amd64
-RUN mv shuttle-linux-amd64 /usr/local/bin/shuttle
-
-WORKDIR /tmp/shuttle/
-
-USER docker
-
-CMD ["shuttle"]
-```
+Shuttle can be put in a container building the Dockerfile supplied in this root folder
 
 Build the container
 ```


### PR DESCRIPTION
If the container doesnt have `bash` installed, shuttle will give an unexpected error if the user tries to call a Bash script along the lines of "File not found". This fixes it.